### PR TITLE
AuthProvider 구현 & 로그인 페이지 수정

### DIFF
--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,17 +1,13 @@
-import { createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 import axios from "@/lib/axios";
 import { useContext } from "react";
 
-const AuthContext = createContext({
-  user: null,
-  login: () => {},
-  logout: () => {},
-});
+const AuthContext = createContext();
 
 export function useAuth() {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error('반드시 AuthProvider 안에서 사용해야 합니다.')
+    throw new Error("반드시 AuthProvider 안에서 사용해야 합니다.");
   }
 
   return context;
@@ -20,24 +16,40 @@ export function useAuth() {
 export default function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
 
-  async function getMyProfile(email) {
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        const res = await axios.get('/api/v1/auth/verify');
+        setUser(res.data.user);
+      } catch(err) {
+        console.log('유저 복원 실패',err);
+        setUser(null);
+      };
+    }
+
+    initAuth();
+  }, [])
+
+  async function login({ email, password }) {
     try {
-      const res = await axios.get(`/api/v1/users/profile/${email}`);
-      const profile = res.data;
-      setUser(profile);
+      const res = await axios.post("/api/v1/auth/login", { email, password });
+      const data = res.data.user;
+
+      setUser(data);
+      if (process.env.NODE_ENV === "development") {
+        console.log("프로필 조회:", data);
+      }
+      return data;
+
     } catch (err) {
-      console.log('프로필 조회 에러:',err);
+      const errorMessage = err.response?.data?.message || "로그인 중 오류가 발생했습니다.";
+      console.log("로그인 실패:", errorMessage);
+      throw new error(errorMessage);
     }
   }
 
-  async function login({ email, password }) {
-    const res = await axios.post("/api/v1/auth/login", { email, password });
-    const resultEmail = res.data.user.email;
-    
-    await getMyProfile(resultEmail);
-  }
-
-  async function logout() {   //임시입니다
+  async function logout() {
+    //임시입니다
     try {
       await axios.post("/api/v1/auth/logout");
       setUser(null);
@@ -45,7 +57,6 @@ export default function AuthProvider({ children }) {
       console.error("로그아웃 에러:", err);
     }
   }
-  
 
   return <AuthContext.Provider value={{ user, login, logout }}>{children}</AuthContext.Provider>;
 }

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,0 +1,51 @@
+import { createContext, useState } from "react";
+import axios from "@/lib/axios";
+import { useContext } from "react";
+
+const AuthContext = createContext({
+  user: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('반드시 AuthProvider 안에서 사용해야 합니다.')
+  }
+
+  return context;
+}
+
+export default function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+
+  async function getMyProfile(email) {
+    try {
+      const res = await axios.get(`/api/v1/users/profile/${email}`);
+      const profile = res.data;
+      setUser(profile);
+    } catch (err) {
+      console.log('프로필 조회 에러:',err);
+    }
+  }
+
+  async function login({ email, password }) {
+    const res = await axios.post("/api/v1/auth/login", { email, password });
+    const resultEmail = res.data.user.email;
+    
+    await getMyProfile(resultEmail);
+  }
+
+  async function logout() {   //임시입니다
+    try {
+      await axios.post("/api/v1/auth/logout");
+      setUser(null);
+    } catch (err) {
+      console.error("로그아웃 에러:", err);
+    }
+  }
+  
+
+  return <AuthContext.Provider value={{ user, login, logout }}>{children}</AuthContext.Provider>;
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -2,6 +2,7 @@ import "@/styles/globals.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import Layout from "@/components/layout";
+import AuthProvider from "@/contexts/AuthProvider";
 
 const queryClient = new QueryClient();
 
@@ -10,9 +11,9 @@ export default function App({ Component, pageProps }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      
-      {getLayout(<Component {...pageProps} />)}
-      
+      <AuthProvider>
+        {getLayout(<Component {...pageProps} />)}
+      </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -2,8 +2,11 @@ import React, { useState } from "react";
 import axios from "axios";
 import Image from "next/image";
 import Link from "next/link";
+import { useAuth } from "@/contexts/AuthProvider";
 
 export default function Login() {
+  const {user, login, logout} = useAuth();
+
   const [email, setEmail] = useState(""); // 이메일 상태
   const [password, setPassword] = useState(""); // 비밀번호 상태
   const [showPassword, setShowPassword] = useState(false); // 비밀번호 보여주기 상태
@@ -23,15 +26,15 @@ export default function Login() {
       const data = response.data;
 
       // 로그인 성공 처리
-      setMessage(`로그인 성공! 환영합니다, ${data.user.nickName}`);
-      console.log("로그인 성공:", data);
+      login({ email, password });
+      setMessage(`로그인 성공! 환영합니다, ${user.nickName}`);
 
       // 토큰 저장
       localStorage.setItem("accessToken", data.accessToken);
       localStorage.setItem("refreshToken", data.refreshToken);
 
       // 페이지 이동
-      window.location.href = "/market";
+      // window.location.href = "/market";
     } catch (error) {
       // 오류 메시지 처리
       const errorMessage = error.response?.data?.message || "로그인 실패";

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -3,12 +3,16 @@ import axios from "axios";
 import Image from "next/image";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthProvider";
+import { useRouter } from "next/router";
 
 export default function Login() {
-  const {user, login, logout} = useAuth();
+  const { user, login, logout } = useAuth();
+
+  const router = useRouter();
 
   const [email, setEmail] = useState(""); // 이메일 상태
   const [password, setPassword] = useState(""); // 비밀번호 상태
+  const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false); // 비밀번호 보여주기 상태
   const [message, setMessage] = useState(""); // 로그인 메시지
 
@@ -18,28 +22,19 @@ export default function Login() {
 
   const handleLogin = async (e) => {
     e.preventDefault();
+    setLoading(true);
     try {
-      const response = await axios.post("http://localhost:8000/api/v1/auth/login", {
-        email,
-        password,
-      });
-      const data = response.data;
+      const data = await login({ email, password });
+      setMessage(`로그인 성공! 환영합니다, ${data.nickName}`);
 
-      // 로그인 성공 처리
-      login({ email, password });
-      setMessage(`로그인 성공! 환영합니다, ${user.nickName}`);
-
-      // 토큰 저장
-      localStorage.setItem("accessToken", data.accessToken);
-      localStorage.setItem("refreshToken", data.refreshToken);
-
-      // 페이지 이동
-      // window.location.href = "/market";
+      router.push('/me');
     } catch (error) {
       // 오류 메시지 처리
       const errorMessage = error.response?.data?.message || "로그인 실패";
       setMessage(errorMessage);
       console.error("로그인 실패:", errorMessage);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -59,10 +54,7 @@ export default function Login() {
         <form onSubmit={handleLogin} className="text-left">
           {/* 이메일 입력 */}
           <div className="mb-4">
-            <label
-              htmlFor="email"
-              className="block text-lg font-normal text-gray-300 mb-2"
-            >
+            <label htmlFor="email" className="block text-lg font-normal text-gray-300 mb-2">
               이메일
             </label>
             <input
@@ -77,10 +69,7 @@ export default function Login() {
 
           {/* 비밀번호 입력 */}
           <div className="mb-6 relative">
-            <label
-              htmlFor="password"
-              className="block text-lg font-normal text-gray-300 mb-2"
-            >
+            <label htmlFor="password" className="block text-lg font-normal text-gray-300 mb-2">
               비밀번호
             </label>
             <input
@@ -100,11 +89,7 @@ export default function Login() {
               <Image
                 width={24}
                 height={24}
-                src={
-                  showPassword
-                    ? "/images/type=visible.png"
-                    : "/images/type=invisible.png"
-                }
+                src={showPassword ? "/images/type=visible.png" : "/images/type=invisible.png"}
                 alt="비밀번호 표시 토글"
               />
             </button>
@@ -115,22 +100,17 @@ export default function Login() {
             type="submit"
             className="w-full h-[60px] bg-customMain text-black font-semibold hover:bg-customMain/80 transition"
           >
-            로그인
+            {loading ? "로그인 중..." : "로그인"}
           </button>
         </form>
 
         {/* 로그인 메시지 */}
-        {message && (
-          <p className="mt-4 text-center text-yellow-400 font-medium">{message}</p>
-        )}
+        {message && <p className="mt-4 text-center text-yellow-400 font-medium">{message}</p>}
 
         {/* 회원가입 안내문 */}
         <p className="mt-6 text-center text-white font-normal text-base">
           최애의 포토가 처음이신가요?{" "}
-          <Link
-            href="/signup"
-            className="text-customMain underline hover:no-underline"
-          >
+          <Link href="/signup" className="text-customMain underline hover:no-underline">
             회원가입하기
           </Link>
         </p>

--- a/src/pages/me.jsx
+++ b/src/pages/me.jsx
@@ -1,0 +1,16 @@
+import { useAuth } from "@/contexts/AuthProvider"
+
+export default function Me() {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <p>로그인하지 않았습니다.</p>; // 유저 정보가 없을 때
+  }
+
+  return (
+    <div>
+      <h1>환영합니다, {user.nickName}님!</h1>
+      <p>이메일: {user.email}</p>
+    </div>
+  );
+}

--- a/src/pages/signup.jsx
+++ b/src/pages/signup.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Link from "next/link";
-import axios from "axios";
+import axios from "@/lib/axios";
 import Image from "next/image";
 import EmailInput from "@/components/shared/EmailInput";
 import NickNameInput from "@/components/signUp/NickNameInput";
@@ -10,8 +10,6 @@ import SignUpModal from "@/components/signUp/SignUpModal";
 
 export default function Signup() {
   const [isOpen, setIsOpen] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [formData, setFormData] = useState({
     email: "",
     password: "",
@@ -38,7 +36,7 @@ export default function Signup() {
 
     const { email, nickName, password } = formData;
     try {
-      const res = await axios.post("http://localhost:8000/api/v1/auth/signup", {
+      const res = await axios.post("/api/v1/auth/signup", {
         email,
         nickName,
         password,


### PR DESCRIPTION
## AuthProvider
- useAuth 훅 구현 -> { user, login, logout } = useAuth() 로 가져와서 사용
- user, login, logout 관리(logout은 아직 구현X)
- useEffect를 통한 토큰 검증(Verify API 이용)을 통해 유저 정보 복구(initAuth) id,email,nickName 포함됨

## login 페이지
- 로그인 성공시 /me라는 임시의 페이지로 라우팅(useRouter push)되게 변경(기존 코드 window.location.href)
- 로그인 함수는 useAuth를 통해 가져와서 사용(이메일과 비밀번호만 넣어주면 됨)
- 로그인 처리되는 동안 로딩 처리(로그인 버튼에 로그인 중... )
- 컴포넌트 갈아끼우기는 아직 진행X
